### PR TITLE
Etcd Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
-  - 0.8
+  - "iojs"
+  - "0.12"
+  - "0.11"
+  - "0.10"
 
 before_script:
   - npm install -g grunt-cli

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Gofigure currently handles the loading of JSON files for configurations.
 
 To Get an instance of a configuration object use the `gofigure` method. The `gofigure` method takes an object that accepts the following options
 
-  * [locations](#loadDir)  : an array of directories that contain your configurations.
+  * [locations](#loadDir)  : an array of directories or [an Etcd server definition](#loadEtcd) that contain your configurations.
   * [files](#loadFiles)  : an array of files that contain your configurations.        
   * [monitor](#monitoring) : set to true to monitor changes to configuration files.
   * `ignoreMissing` : By default `gofigure` will ignore missing directories. Set this to false to precent the ignoring of missing configuration directories.
@@ -180,7 +180,7 @@ See [below](#etcdconfig) for notes about the supported Etcd layout.
 Gofigure supports the monitoring of changes to configuration files. 
 
 <a name="monitoringAll"></a>
-### All files
+### All files or Etcd server
 
 To enable monitoring you can specify monitor to true in the options.
 
@@ -544,7 +544,7 @@ Please see [Etcd Notes](#etcdconfig) for the supported Etcd layout for `NODE_TYP
 
 The expected layout within Etcd is the following:
 
-127.0.0.1:4001/v2/keys/&lt;root&gt;/environment/&lt;environment name&gt;
+127.0.0.1:4001/v2/keys/&lt;root&gt;/&lt;NODE_ENV&gt;
 
 So, in the example above, `gofigure` will look for the following:
 
@@ -558,13 +558,13 @@ var ETCD_CONFIG = {endpoints: ["127.0.0.1:4001"], root: "/appname"};
 
 at this location within Etcd for keys:
 
-127.0.0.1:4001/v2/keys/appname/environment/production
+127.0.0.1:4001/v2/keys/appname/production
 
 ###Type Layout
 
 If process.env.NODE_TYPE is set, `gofigure` will look for the following:
 
-127.0.0.1:4001/v2/keys/&lt;root&gt;/environment/&lt;node type&gt;/&lt;environment name&gt;
+127.0.0.1:4001/v2/keys/&lt;root&gt;/type/&lt;NODE_ENV&gt;/&lt;NODE_TYPE&gt;
 
 For the following example:
 
@@ -579,7 +579,7 @@ var ETCD_CONFIG = {endpoints: ["127.0.0.1:4001"], root: "/appname"};
 
 `gofigure` will look at this location within Etcd for keys:
 
-127.0.0.1:4001/v2/keys/appname/environment/type/webapp/production
+127.0.0.1:4001/v2/keys/appname/type/production/webapp
 
 
 ###Special Environment Names

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # gofigure
 
-Gofigure is a configuration tool for node to help in the gathering and monitoring of configuration files in node. 
+Gofigure is a configuration tool for node to help in the gathering and monitoring of configuration files in node.
 
 # Installation
 
@@ -17,17 +17,17 @@ For nodejs < 0.10:
 ```
 $ npm install gofigure@0.1.2
 ```
-    
+
 # Usage
 
-   
-  * [Loading A Configuration](#load)        
-    * [Directories](#loadDir)         
+
+  * [Loading A Configuration](#load)
+    * [Directories](#loadDir)
     * [Files](#loadFiles)
     * [Etcd](#loadEtcd)
   * [Monitoring Property Changes](#monitoring)
-    * [Monitoring All Files](#monitoringAll)   
-    * [Monitoring Certain Files](#monitoringSome)   
+    * [Monitoring All Files](#monitoringAll)
+    * [Monitoring Certain Files](#monitoringSome)
     * [Property Topic Syntax](#monitoringSyntax)
     * [Property Change Callback](#monitoringCB)
   * [Environments](#environments)
@@ -36,18 +36,18 @@ $ npm install gofigure@0.1.2
 <a name="load"></a>
 ## Loading configurations
 
-Gofigure currently handles the loading of JSON files for configurations. 
+Gofigure currently handles the loading of JSON files for configurations.
 
 To Get an instance of a configuration object use the `gofigure` method. The `gofigure` method takes an object that accepts the following options
 
   * [locations](#loadDir)  : an array of directories or [an Etcd server definition](#loadEtcd) that contain your configurations.
-  * [files](#loadFiles)  : an array of files that contain your configurations.        
+  * [files](#loadFiles)  : an array of files that contain your configurations.
   * [monitor](#monitoring) : set to true to monitor changes to configuration files.
   * `ignoreMissing` : By default `gofigure` will ignore missing directories. Set this to false to precent the ignoring of missing configuration directories.
   * [environment](#environments) : By default will look for `process.env.NODE_ENV` if this is not set then gofigure will read all properties. If you wish to explicity set the environment then set this property.
   * `defaultEnvironment` [`*`]: The key that represents default values to be set when an environment is used.
 
-```javascript 
+```javascript
 
 var gofigure = require("gofigure");
 
@@ -153,6 +153,18 @@ loader.load(function(err, config){
 });
 ```
 
+Synchronous loading from Etcd is also supported.
+
+```javascript
+var gofigure = require("gofigure");
+
+var ETCD_CONFIG = {endpoints: ["127.0.0.1:4001"], root: "/appname"};
+
+var loader = gofigure({locations : [ETCD_CONFIG]});
+var config = loader.loadSync();
+var PORT = config.port, HOST = config.host;
+```
+
 If your Etcd server requires SSL/TLS and specific certificates, ssloptions can be passed as well.
 
 ```javascript
@@ -177,7 +189,7 @@ See [below](#etcdconfig) for notes about the supported Etcd layout.
 <a name="monitoring"></a>
 ## Monitoring
 
-Gofigure supports the monitoring of changes to configuration files. 
+Gofigure supports the monitoring of changes to configuration files.
 
 <a name="monitoringAll"></a>
 ### All files or Etcd server
@@ -203,11 +215,11 @@ To monitor certain files you can use the files property and with object that hav
 var gofigure = require("gofigure");
 
 var loader = gofigure({files : [
-  { 
-    file : "/prod/configs/config1.json", 
+  {
+    file : "/prod/configs/config1.json",
     monitor : true
-    
-  }, 
+
+  },
   __dirname + "/config.json"
 ]});
 var config = loader.loadSync();
@@ -280,7 +292,7 @@ loading.on("my.cool.{property|otherProperty}", function(propName, newValue){
   //...do something
 });
 
-//listen to the change of property or otherProperty on the my cool or 
+//listen to the change of property or otherProperty on the my cool or
 //notCool object.
 loading.on("my.{cool|notCool}.{property|otherProperty}", function(propName, newValue){
   //...do something
@@ -330,7 +342,7 @@ loading.on("my.cool.property", function(propName, newValue, configObject){
 <a name="environments"></a>
 ##Environments
 
-`gofigure` also supports environments, by default it will look for `NODE_ENV` and if it is set then it will use it. 
+`gofigure` also supports environments, by default it will look for `NODE_ENV` and if it is set then it will use it.
 
 The following is an example configuration file
 
@@ -345,7 +357,7 @@ The following is an example configuration file
 				        {
 					        "type":"RollingFileAppender",
 					        "file":"/var/log/myApp/patio.log"
-				        },								
+				        },
 				        {
 					        "type":"ConsoleAppender"
 				        }
@@ -376,7 +388,7 @@ The following is an example configuration file
           "port" : "80"
         },
         "MYSQL_DB" : "mysql://test:testpass@prod.mydomain.com:3306/prod_db",
-        "MONGO_DB" : "mongodb://test:testpass@prod.mydomain.com:27017/prd_db"        
+        "MONGO_DB" : "mongodb://test:testpass@prod.mydomain.com:27017/prd_db"
     },
     "test": {
         "logging":{
@@ -386,7 +398,7 @@ The following is an example configuration file
 				        {
 					        "type":"RollingFileAppender",
 					        "file":"/var/log/myApp/patio.log"
-				        }												        
+				        }
 			        ]
 		        }
         },
@@ -395,7 +407,7 @@ The following is an example configuration file
           "port" : "80"
         },
         "MYSQL_DB" : "mysql://test:testpass@test.mydomain.com:3306/test_db",
-        "MONGO_DB" : "mongodb://test:testpass@test.mydomain.com:27017/test_db"        
+        "MONGO_DB" : "mongodb://test:testpass@test.mydomain.com:27017/test_db"
     }
 }
 
@@ -599,7 +611,3 @@ Meta
 
 * Code: `git clone git://github.com/c2fo/gofigure.git`
 * Website:  <http://c2fo.com> - Twitter: <http://twitter.com/c2fo> - 877.465.4045
-
-
-
-

--- a/lib/extended.js
+++ b/lib/extended.js
@@ -10,7 +10,9 @@ var _ = require("extended")()
     .register(require("fs"));
 
 function createGlobPattern(file) {
-    if (/\.json$/.test(file)) {
+    if (file === undefined) {
+        return;
+    } else if (/\.json$/.test(file)) {
         return file;
     } else {
         return _.resolve(file, "**/*.json");

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,6 @@ var Config = PatternEventEmitter.extend({
             if (files) {
                 this.files = toArray(files || []).reverse();
             }
-            console.log(this.environment);
             _.merge(this, opts);
         },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,8 @@ var Config = PatternEventEmitter.extend({
 
         environment: process.env.NODE_ENV || null,
 
+        nodetype: process.env.NODE_TYPE || null,
+
         defaultEnvironment: "*",
 
         config: null,
@@ -97,12 +99,16 @@ var Config = PatternEventEmitter.extend({
         },
 
         __mergeConfigs: function (configs, emit) {
-            var env = this.environment, defEnv = this.defaultEnvironment, newConfig = _.deepMerge({}, this.config);
+            var env = this.environment, nodetype = this.nodetype, defEnv = this.defaultEnvironment, newConfig = _.deepMerge({}, this.config);
             configs.forEach(function (c) {
                 if (env) {
                     c = _.deepMerge({}, c[defEnv] || {}, c[env] || {});
                 }
                 _.deepMerge(newConfig, c);
+                /* if (nodetype) { // Merge the node type
+                    c = _.deepMerge({}, c.nodetype.[env][nodetype] || {});
+                }
+                _.deepMerge(newConfig, c); */
             });
             this.__merge("", newConfig, this.config);
             return newConfig;

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,6 +52,7 @@ var Config = PatternEventEmitter.extend({
             if (files) {
                 this.files = toArray(files || []).reverse();
             }
+            console.log(this.environment);
             _.merge(this, opts);
         },
 
@@ -99,16 +100,18 @@ var Config = PatternEventEmitter.extend({
         },
 
         __mergeConfigs: function (configs, emit) {
-            var env = this.environment, nodetype = this.nodetype, defEnv = this.defaultEnvironment, newConfig = _.deepMerge({}, this.config);
+            var env = this.environment, 
+                nodetype = this.nodetype, 
+                defEnv = this.defaultEnvironment, 
+                newConfig = _.deepMerge({}, this.config);
             configs.forEach(function (c) {
                 if (env) {
-                    c = _.deepMerge({}, c[defEnv] || {}, c[env] || {});
+                    c = _.deepMerge({}, 
+                        c[defEnv] || {}, 
+                        c[env] || {}, 
+                        ((((c || {})['type'] || {})[env] || {})[nodetype] || {}));
                 }
                 _.deepMerge(newConfig, c);
-                /* if (nodetype) { // Merge the node type
-                    c = _.deepMerge({}, c.nodetype.[env][nodetype] || {});
-                }
-                _.deepMerge(newConfig, c); */
             });
             this.__merge("", newConfig, this.config);
             return newConfig;

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,6 +1,7 @@
 var _ = require("./extended"),
     EventEmitter = require("./events").EventEmitter,
-    readFileP = _.wrap(_.readFile, _);
+    readFileP = _.wrap(_.readFile, _)
+    Etcd = require("node-etcd");
 
 EventEmitter.extend({
 
@@ -26,6 +27,12 @@ EventEmitter.extend({
             this.config = {};
             this.fileGlob = _.createGlobPattern(this.file);
             _.merge(this, options);
+            if (this.endpoints) {
+                console.log(this);
+                this.etcd = this.ssloptions ? 
+                    new Etcd(this.endpoints, this.ssloptions) : 
+                    new Etcd(this.endpoints);
+            }
             _.bindAll(this, ["watch", "watchHandler", "emit"]);
         },
 
@@ -70,18 +77,23 @@ EventEmitter.extend({
         loadSync: function () {
             if (!this.loaded) {
                 var c = this.config = {};
-                (this.files = _.glob.sync(this.fileGlob).sort()).map(function (file) {
-                    try {
-                        return JSON.parse(_.readFileSync(file, "utf8"));
-                    } catch (e) {
-                        throw new Error("Error parsing " + file + ": " + e.message);
+                if(this.fileGlob !== undefined) { //Process files
+                    (this.files = _.glob.sync(this.fileGlob).sort()).map(function (file) {
+                        try {
+                            return JSON.parse(_.readFileSync(file, "utf8"));
+                        } catch (e) {
+                            throw new Error("Error parsing " + file + ": " + e.message);
+                        }
+                    }).forEach(function (newC) {
+                            _.deepMerge(c, newC);
+                        });
+                    this.loaded = true;
+                    if (this.monitor) {
+                        this.watch();
                     }
-                }).forEach(function (newC) {
-                        _.deepMerge(c, newC);
-                    });
-                this.loaded = true;
-                if (this.monitor) {
-                    this.watch();
+                } else if(this.endpoints) { //Process etcd
+                    var etcdresp = this.etcd.getSync(this.root + "/environment", { recursive: true });
+                    console.log(etcdresp);
                 }
             }
             return this.config;
@@ -90,25 +102,27 @@ EventEmitter.extend({
 
         load: function () {
             if (!this.loaded) {
-                return _.wrap(_.glob, _)(this.fileGlob)
-                    .then(function (files) {
-                        this.files = files.sort();
-                        return _.when(files.map(function (file) {
-                            return readFileP(file, "utf8").then(function (contents) {
-                                return JSON.parse(contents);
-                            });
-                        }));
-                    }.bind(this))
-                    .then(function (files) {
-                        this.loaded = true;
-                        var ret = (this.config = _.deepMerge.apply(_, [
-                            {}
-                        ].concat(files)));
-                        if (this.monitor) {
-                            this.watch();
-                        }
-                        return ret;
+                if (this.fileGlob !== undefined) {
+                    return _.wrap(_.glob, _)(this.fileGlob)
+                        .then(function (files) {
+                            this.files = files.sort();
+                            return _.when(files.map(function (file) {
+                                return readFileP(file, "utf8").then(function (contents) {
+                                    return JSON.parse(contents);
+                                });
+                            }));
+                        }.bind(this))
+                        .then(function (files) {
+                            this.loaded = true;
+                            var ret = (this.config = _.deepMerge.apply(_, [
+                                {}
+                            ].concat(files)));
+                            if (this.monitor) {
+                                this.watch();
+                            }
+                            return ret;
                     }.bind(this));
+                }
             } else {
                 return _.resolve(this.config);
             }

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,7 +1,7 @@
 var _ = require("./extended"),
     EventEmitter = require("./events").EventEmitter,
     readFileP = _.wrap(_.readFile, _)
-    Etcd = require("node-etcd");
+    Etcd = require("../../node-etcd/lib/");
 
 EventEmitter.extend({
 
@@ -39,13 +39,26 @@ EventEmitter.extend({
             if (this.watching) {
                 var emit = this.emit, config = this.config;
                 if (event === "change") {
-                    clearTimeout(this.watchTimeout);
-                    //use a timeout incase the file changes again
-                    this.watchTimeout = setTimeout(function () {
-                        readFileP(file, "utf8").then(function (contents) {
-                            emit("change", _.deepMerge(config, JSON.parse(contents)));
-                        });
-                    }, 10);
+                    if (this.etcdwatcher !== undefined) {
+                        var cfg = tmpcfg = {};
+                        var parsedKey = this.etcdregex.exec(file.node.key);
+                        var keyLocation = parsedKey[1];
+                        objNames = keyLocation.split("/");
+                        while(objNames.length > 1){
+                            var objName = objNames.shift().replace(/\+/g, " ");
+                            tmpcfg = tmpcfg[objName] = {};
+                        }
+                        tmpcfg[objNames[0]] = JSON.parse(file.node.value);
+                        emit("change", _.deepMerge(config, cfg));
+                    } else {
+                        clearTimeout(this.watchTimeout);
+                        //use a timeout incase the file changes again
+                        this.watchTimeout = setTimeout(function () {
+                            readFileP(file, "utf8").then(function (contents) {
+                                emit("change", _.deepMerge(config, JSON.parse(contents)));
+                            });
+                        }, 10);
+                    }
                 }
             }
         },
@@ -53,10 +66,14 @@ EventEmitter.extend({
         unWatch: function () {
             if (this.watching) {
                 this.watching = false;
-                clearTimeout(this.watchTimeout);
-                this.files.forEach(function (file) {
-                    _.unwatchFile(file, this.watchHandler);
-                }, this);
+                if (this.etcdwatcher !== undefined) {
+                    this.etcdwatcher.stop();
+                } else {
+                    clearTimeout(this.watchTimeout);
+                    this.files.forEach(function (file) {
+                        _.unwatchFile(file, this.watchHandler);
+                    }, this);
+                }
             }
             return this;
         },
@@ -64,11 +81,17 @@ EventEmitter.extend({
         watch: function () {
             if (!this.watching) {
                 this.watching = true;
-                this.files.forEach(function (file) {
-                    _.watch(file, function (event) {
-                        this.watchHandler(event, file);
-                    }.bind(this));
-                }, this);
+                if (this.etcd !== undefined) {
+                    this.etcdwatcher = 
+                        this.etcd.watcher(this.root + "/environment", null, { recursive: true });
+                    this.etcdwatcher.on("change", this.watchHandler.bind(this, "change"));
+                } else {
+                    this.files.forEach(function (file) {
+                        _.watch(file, function (event) {
+                            this.watchHandler(event, file);
+                        }.bind(this));
+                    }, this);
+                }
             }
             return this;
         },
@@ -87,15 +110,16 @@ EventEmitter.extend({
                             _.deepMerge(c, newC);
                         });
                     this.loaded = true;
-                    if (this.monitor) {
-                        this.watch();
-                    }
-                } else if(this.endpoints) { //Process etcd
+                } else if (this.endpoints) { //Process etcd
                     var etcdresp = this.etcd.getSync(this.root + "/environment", { recursive: true });
-                    var basePath = this.root + "/environment";
-                    var keyRegex = new RegExp(basePath + "/(.*)");
-                    this.__processNodes(etcdresp.body.node.nodes, keyRegex, c);
+                    if (etcdresp.err){
+                        throw new Error("Etcd problem:  " + etcdresp.err.message);
+                    }
+                    this.__processNodes(etcdresp.body.node.nodes, c);
                     this.loaded = true;
+                }
+                if (this.monitor) {
+                    this.watch();
                 }
             }
             return this.config;
@@ -104,7 +128,7 @@ EventEmitter.extend({
 
         load: function () {
             if (!this.loaded) {
-                if (this.fileGlob !== undefined) {
+                if (this.fileGlob !== undefined) { //Process files
                     return _.wrap(_.glob, _)(this.fileGlob)
                         .then(function (files) {
                             this.files = files.sort();
@@ -113,28 +137,40 @@ EventEmitter.extend({
                                     return JSON.parse(contents);
                                 });
                             }));
-                        }.bind(this))
-                        .then(function (files) {
-                            this.loaded = true;
-                            var ret = (this.config = _.deepMerge.apply(_, [
-                                {}
-                            ].concat(files)));
-                            if (this.monitor) {
-                                this.watch();
-                            }
-                            return ret;
-                    }.bind(this));
+                        }.bind(this)).then(this.__asyncmerge.bind(this));
+                } else if (this.endpoints) { //process etcd
+                    return _.wrap(this.etcd.get, this.etcd)(this.root + "/environment", {recursive: true})
+                        .then(function (etcdbody, etcdheaders) {
+                            var workingconfig = {};
+                            this.__processNodes(etcdbody.node.nodes, workingconfig);
+                            return workingconfig;
+                        }.bind(this)).then(this.__asyncmerge.bind(this));
                 }
             } else {
                 return _.resolve(this.config);
             }
         },
 
-        __processNodes: function(nodes, regex, cfg){
+        __asyncmerge: function(configs) {
+            var ret = (this.config = _.deepMerge.apply(_, [
+                {}
+            ].concat(configs)));
+            this.loaded = true;
+            if (this.monitor) {
+                this.watch();
+            }
+            return ret;
+        },
+
+        __processNodes: function(nodes, cfg){
+            if (this.etcdregex === undefined) {
+                var basePath = this.root + "/environment";
+                this.etcdregex = new RegExp(basePath + "/(.*)");
+            }
             for(var i = 0; i < nodes.length; i++){
                 if(nodes[i].dir){
                     var newCfg = {};
-                    var emptyObject = regex.exec(nodes[i].key);
+                    var emptyObject = this.etcdregex.exec(nodes[i].key);
                     if(emptyObject.length < 2){
                         continue;
                     }
@@ -143,10 +179,10 @@ EventEmitter.extend({
                     var emptyObjectName = emptyObjectPath[emptyObjectPath.length - 1].replace(/\+/g, " ");
                     cfg[emptyObjectName] = newCfg;
                     if(nodes[i].nodes !== undefined){
-                        this.__processNodes(nodes[i].nodes, regex, newCfg);
+                        this.__processNodes(nodes[i].nodes, newCfg);
                     }
                 } else {
-                    var parsedKey = regex.exec(nodes[i].key);
+                    var parsedKey = this.etcdregex.exec(nodes[i].key);
                     var keyLocation = parsedKey[1];
                     objNames = keyLocation.split("/");
                     var valueName = objNames[objNames.length - 1].replace(/\+/g, " ");

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -28,7 +28,6 @@ EventEmitter.extend({
             this.fileGlob = _.createGlobPattern(this.file);
             _.merge(this, options);
             if (this.endpoints) {
-                console.log(this);
                 this.etcd = this.ssloptions ? 
                     new Etcd(this.endpoints, this.ssloptions) : 
                     new Etcd(this.endpoints);
@@ -93,7 +92,10 @@ EventEmitter.extend({
                     }
                 } else if(this.endpoints) { //Process etcd
                     var etcdresp = this.etcd.getSync(this.root + "/environment", { recursive: true });
-                    console.log(etcdresp);
+                    var basePath = this.root + "/environment";
+                    var keyRegex = new RegExp(basePath + "/(.*)");
+                    this.__processNodes(etcdresp.body.node.nodes, keyRegex, c);
+                    this.loaded = true;
                 }
             }
             return this.config;
@@ -125,6 +127,31 @@ EventEmitter.extend({
                 }
             } else {
                 return _.resolve(this.config);
+            }
+        },
+
+        __processNodes: function(nodes, regex, cfg){
+            for(var i = 0; i < nodes.length; i++){
+                if(nodes[i].dir){
+                    var newCfg = {};
+                    var emptyObject = regex.exec(nodes[i].key);
+                    if(emptyObject.length < 2){
+                        continue;
+                    }
+                    var emptyObjectLocation = emptyObject[1];
+                    var emptyObjectPath = emptyObjectLocation.split("/");
+                    var emptyObjectName = emptyObjectPath[emptyObjectPath.length - 1].replace(/\+/g, " ");
+                    cfg[emptyObjectName] = newCfg;
+                    if(nodes[i].nodes !== undefined){
+                        this.__processNodes(nodes[i].nodes, regex, newCfg);
+                    }
+                } else {
+                    var parsedKey = regex.exec(nodes[i].key);
+                    var keyLocation = parsedKey[1];
+                    objNames = keyLocation.split("/");
+                    var valueName = objNames[objNames.length - 1].replace(/\+/g, " ");
+                    cfg[valueName] = JSON.parse(nodes[i].value);
+                }
             }
         }
     }

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,7 +1,7 @@
 var _ = require("./extended"),
     EventEmitter = require("./events").EventEmitter,
     readFileP = _.wrap(_.readFile, _)
-    Etcd = require("../../node-etcd/lib/");
+    Etcd = require("node-etcd");
 
 EventEmitter.extend({
 
@@ -83,7 +83,7 @@ EventEmitter.extend({
                 this.watching = true;
                 if (this.etcd !== undefined) {
                     this.etcdwatcher = 
-                        this.etcd.watcher(this.root + "/environment", null, { recursive: true });
+                        this.etcd.watcher(this.root, null, { recursive: true });
                     this.etcdwatcher.on("change", this.watchHandler.bind(this, "change"));
                 } else {
                     this.files.forEach(function (file) {
@@ -111,7 +111,7 @@ EventEmitter.extend({
                         });
                     this.loaded = true;
                 } else if (this.endpoints) { //Process etcd
-                    var etcdresp = this.etcd.getSync(this.root + "/environment", { recursive: true });
+                    var etcdresp = this.etcd.getSync(this.root, { recursive: true });
                     if (etcdresp.err){
                         throw new Error("Etcd problem:  " + etcdresp.err.message);
                     }
@@ -139,7 +139,7 @@ EventEmitter.extend({
                             }));
                         }.bind(this)).then(this.__asyncmerge.bind(this));
                 } else if (this.endpoints) { //process etcd
-                    return _.wrap(this.etcd.get, this.etcd)(this.root + "/environment", {recursive: true})
+                    return _.wrap(this.etcd.get, this.etcd)(this.root, {recursive: true})
                         .then(function (etcdbody, etcdheaders) {
                             var workingconfig = {};
                             this.__processNodes(etcdbody.node.nodes, workingconfig);
@@ -164,8 +164,7 @@ EventEmitter.extend({
 
         __processNodes: function(nodes, cfg){
             if (this.etcdregex === undefined) {
-                var basePath = this.root + "/environment";
-                this.etcdregex = new RegExp(basePath + "/(.*)");
+                this.etcdregex = new RegExp(this.root + "/(.*)");
             }
             for(var i = 0; i < nodes.length; i++){
                 if(nodes[i].dir){

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
         "Configurations",
         "JSON",
         "Properties",
-        "Property"
+        "Property",
+        "etcd",
+        "raft"
     ],
     "homepage": "http://c2fo.github.com/gofigure",
     "repository": {
@@ -36,12 +38,16 @@
         "grunt-contrib-jshint": "~0.2.0",
         "nock": "1.1.x"
     },
-    "author": "Doug Martin (doug.martin@pollenware.com)",
+    "author": "Doug Martin (doug.martin@c2fo.com)",
     "main": "index.js",
     "directories": {
         "lib": "lib"
     },
     "engines": {
         "node": ">= 0.10.0"
-    }
+    },
+    "contributors": [{
+        "name": "Bryan Rockwood",
+        "email": "bryan.rockwood@c2fo.com"
+    }]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "gofigure",
     "description": "Configuration helper for node",
-    "version": "0.1.2",
+    "version": "0.2.0",
     "scripts": {
         "test": "grunt it"
     },
@@ -27,13 +27,14 @@
         "object-extended": "0.0.3",
         "declare.js": "0.0.4",
         "glob": "~3.1.21",
-        "node-etcd": "4.0.0"
+        "node-etcd": "4.0.x"
     },
     "devDependencies": {
         "it": "~0.2.0",
         "grunt": "~0.4.0",
         "grunt-it": "~0.3.0",
-        "grunt-contrib-jshint": "~0.2.0"
+        "grunt-contrib-jshint": "~0.2.0",
+        "nock": "1.1.x"
     },
     "author": "Doug Martin (doug.martin@pollenware.com)",
     "main": "index.js",
@@ -41,6 +42,6 @@
         "lib": "lib"
     },
     "engines": {
-        "node": ">= 0.6.1"
+        "node": ">= 0.10.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "extended": "0.0.3",
         "object-extended": "0.0.3",
         "declare.js": "0.0.4",
-        "glob": "~3.1.21"
+        "glob": "~3.1.21",
+        "node-etcd": "4.0.0"
     },
     "devDependencies": {
         "it": "~0.2.0",

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
         "url": "git@github.com:C2FO/gofigure.git"
     },
     "dependencies": {
-        "function-extended": "0.0.3",
-        "is-extended": "0.0.4",
-        "array-extended": "0.0.4",
-        "promise-extended": "0.0.3",
-        "extended": "0.0.3",
-        "object-extended": "0.0.3",
-        "declare.js": "0.0.4",
+        "function-extended": "0.0.9",
+        "is-extended": "0.0.10",
+        "array-extended": "0.0.11",
+        "promise-extended": "0.0.9",
+        "extended": "0.0.6",
+        "object-extended": "0.0.7",
+        "declare.js": "0.0.8",
         "glob": "~3.1.21",
         "node-etcd": "4.0.x"
     },

--- a/test/config-etcd/gofigure_queries.json
+++ b/test/config-etcd/gofigure_queries.json
@@ -1,0 +1,2271 @@
+[
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/configs1?recursive=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "get",
+      "node": {
+        "key": "/configs1",
+        "dir": true,
+        "nodes": [
+          {
+            "key": "/configs1/b",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/configs1/b/c",
+                "value": "1",
+                "modifiedIndex": 25,
+                "createdIndex": 25
+              },
+              {
+                "key": "/configs1/b/d",
+                "value": "2",
+                "modifiedIndex": 39,
+                "createdIndex": 39
+              }
+            ],
+            "modifiedIndex": 25,
+            "createdIndex": 25
+          },
+          {
+            "key": "/configs1/e",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/configs1/e/f",
+                "value": "3",
+                "modifiedIndex": 27,
+                "createdIndex": 27
+              },
+              {
+                "key": "/configs1/e/g",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/configs1/e/g/h",
+                    "value": "4",
+                    "modifiedIndex": 28,
+                    "createdIndex": 28
+                  }
+                ],
+                "modifiedIndex": 28,
+                "createdIndex": 28
+              }
+            ],
+            "modifiedIndex": 27,
+            "createdIndex": 27
+          },
+          {
+            "key": "/configs1/a",
+            "value": "1",
+            "modifiedIndex": 24,
+            "createdIndex": 24
+          }
+        ],
+        "modifiedIndex": 24,
+        "createdIndex": 24
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "40",
+      "x-raft-index": "6217",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:16:41 GMT",
+      "content-length": "709"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/configs2?recursive=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "get",
+      "node": {
+        "key": "/configs2",
+        "dir": true,
+        "nodes": [
+          {
+            "key": "/configs2/i",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/configs2/i/j",
+                "value": "5",
+                "modifiedIndex": 30,
+                "createdIndex": 30
+              },
+              {
+                "key": "/configs2/i/k",
+                "value": "6",
+                "modifiedIndex": 31,
+                "createdIndex": 31
+              }
+            ],
+            "modifiedIndex": 30,
+            "createdIndex": 30
+          },
+          {
+            "key": "/configs2/l",
+            "value": "7",
+            "modifiedIndex": 32,
+            "createdIndex": 32
+          },
+          {
+            "key": "/configs2/b",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/configs2/b/c",
+                "value": "2",
+                "modifiedIndex": 29,
+                "createdIndex": 29
+              }
+            ],
+            "modifiedIndex": 29,
+            "createdIndex": 29
+          }
+        ],
+        "modifiedIndex": 29,
+        "createdIndex": 29
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "40",
+      "x-raft-index": "6217",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:16:41 GMT",
+      "content-length": "552"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/config-env?recursive=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "get",
+      "node": {
+        "key": "/config-env",
+        "dir": true,
+        "nodes": [
+          {
+            "key": "/config-env/production",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-env/production/b",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/production/b/d",
+                    "value": "8",
+                    "modifiedIndex": 10,
+                    "createdIndex": 10
+                  },
+                  {
+                    "key": "/config-env/production/b/c",
+                    "value": "7",
+                    "modifiedIndex": 11,
+                    "createdIndex": 11
+                  }
+                ],
+                "modifiedIndex": 10,
+                "createdIndex": 10
+              },
+              {
+                "key": "/config-env/production/e",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/production/e/g",
+                    "dir": true,
+                    "nodes": [
+                      {
+                        "key": "/config-env/production/e/g/h",
+                        "value": "10",
+                        "modifiedIndex": 8,
+                        "createdIndex": 8
+                      }
+                    ],
+                    "modifiedIndex": 8,
+                    "createdIndex": 8
+                  },
+                  {
+                    "key": "/config-env/production/e/f",
+                    "value": "9",
+                    "modifiedIndex": 12,
+                    "createdIndex": 12
+                  }
+                ],
+                "modifiedIndex": 8,
+                "createdIndex": 8
+              },
+              {
+                "key": "/config-env/production/a",
+                "value": "6",
+                "modifiedIndex": 9,
+                "createdIndex": 9
+              }
+            ],
+            "modifiedIndex": 8,
+            "createdIndex": 8
+          },
+          {
+            "key": "/config-env/test",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-env/test/b",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/test/b/d",
+                    "value": "13",
+                    "modifiedIndex": 14,
+                    "createdIndex": 14
+                  },
+                  {
+                    "key": "/config-env/test/b/c",
+                    "value": "12",
+                    "modifiedIndex": 13,
+                    "createdIndex": 13
+                  }
+                ],
+                "modifiedIndex": 13,
+                "createdIndex": 13
+              },
+              {
+                "key": "/config-env/test/e",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/test/e/f",
+                    "value": "14",
+                    "modifiedIndex": 15,
+                    "createdIndex": 15
+                  },
+                  {
+                    "key": "/config-env/test/e/g",
+                    "dir": true,
+                    "nodes": [
+                      {
+                        "key": "/config-env/test/e/g/h",
+                        "value": "15",
+                        "modifiedIndex": 16,
+                        "createdIndex": 16
+                      }
+                    ],
+                    "modifiedIndex": 16,
+                    "createdIndex": 16
+                  }
+                ],
+                "modifiedIndex": 15,
+                "createdIndex": 15
+              },
+              {
+                "key": "/config-env/test/a",
+                "value": "11",
+                "modifiedIndex": 17,
+                "createdIndex": 17
+              }
+            ],
+            "modifiedIndex": 13,
+            "createdIndex": 13
+          },
+          {
+            "key": "/config-env/development",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-env/development/a",
+                "value": "1",
+                "modifiedIndex": 7,
+                "createdIndex": 7
+              },
+              {
+                "key": "/config-env/development/b",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/development/b/d",
+                    "value": "3",
+                    "modifiedIndex": 3,
+                    "createdIndex": 3
+                  },
+                  {
+                    "key": "/config-env/development/b/c",
+                    "value": "2",
+                    "modifiedIndex": 4,
+                    "createdIndex": 4
+                  }
+                ],
+                "modifiedIndex": 3,
+                "createdIndex": 3
+              },
+              {
+                "key": "/config-env/development/e",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/development/e/g",
+                    "dir": true,
+                    "nodes": [
+                      {
+                        "key": "/config-env/development/e/g/h",
+                        "value": "5",
+                        "modifiedIndex": 6,
+                        "createdIndex": 6
+                      }
+                    ],
+                    "modifiedIndex": 6,
+                    "createdIndex": 6
+                  },
+                  {
+                    "key": "/config-env/development/e/f",
+                    "value": "4",
+                    "modifiedIndex": 5,
+                    "createdIndex": 5
+                  }
+                ],
+                "modifiedIndex": 5,
+                "createdIndex": 5
+              }
+            ],
+            "modifiedIndex": 3,
+            "createdIndex": 3
+          }
+        ],
+        "modifiedIndex": 3,
+        "createdIndex": 3
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "40",
+      "x-raft-index": "6217",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:16:41 GMT",
+      "transfer-encoding": "chunked"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/config-env?recursive=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "get",
+      "node": {
+        "key": "/config-env",
+        "dir": true,
+        "nodes": [
+          {
+            "key": "/config-env/development",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-env/development/b",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/development/b/d",
+                    "value": "3",
+                    "modifiedIndex": 3,
+                    "createdIndex": 3
+                  },
+                  {
+                    "key": "/config-env/development/b/c",
+                    "value": "2",
+                    "modifiedIndex": 4,
+                    "createdIndex": 4
+                  }
+                ],
+                "modifiedIndex": 3,
+                "createdIndex": 3
+              },
+              {
+                "key": "/config-env/development/e",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/development/e/f",
+                    "value": "4",
+                    "modifiedIndex": 5,
+                    "createdIndex": 5
+                  },
+                  {
+                    "key": "/config-env/development/e/g",
+                    "dir": true,
+                    "nodes": [
+                      {
+                        "key": "/config-env/development/e/g/h",
+                        "value": "5",
+                        "modifiedIndex": 6,
+                        "createdIndex": 6
+                      }
+                    ],
+                    "modifiedIndex": 6,
+                    "createdIndex": 6
+                  }
+                ],
+                "modifiedIndex": 5,
+                "createdIndex": 5
+              },
+              {
+                "key": "/config-env/development/a",
+                "value": "1",
+                "modifiedIndex": 7,
+                "createdIndex": 7
+              }
+            ],
+            "modifiedIndex": 3,
+            "createdIndex": 3
+          },
+          {
+            "key": "/config-env/production",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-env/production/e",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/production/e/f",
+                    "value": "9",
+                    "modifiedIndex": 12,
+                    "createdIndex": 12
+                  },
+                  {
+                    "key": "/config-env/production/e/g",
+                    "dir": true,
+                    "nodes": [
+                      {
+                        "key": "/config-env/production/e/g/h",
+                        "value": "10",
+                        "modifiedIndex": 8,
+                        "createdIndex": 8
+                      }
+                    ],
+                    "modifiedIndex": 8,
+                    "createdIndex": 8
+                  }
+                ],
+                "modifiedIndex": 8,
+                "createdIndex": 8
+              },
+              {
+                "key": "/config-env/production/a",
+                "value": "6",
+                "modifiedIndex": 9,
+                "createdIndex": 9
+              },
+              {
+                "key": "/config-env/production/b",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/production/b/d",
+                    "value": "8",
+                    "modifiedIndex": 10,
+                    "createdIndex": 10
+                  },
+                  {
+                    "key": "/config-env/production/b/c",
+                    "value": "7",
+                    "modifiedIndex": 11,
+                    "createdIndex": 11
+                  }
+                ],
+                "modifiedIndex": 10,
+                "createdIndex": 10
+              }
+            ],
+            "modifiedIndex": 8,
+            "createdIndex": 8
+          },
+          {
+            "key": "/config-env/test",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-env/test/b",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/test/b/c",
+                    "value": "12",
+                    "modifiedIndex": 13,
+                    "createdIndex": 13
+                  },
+                  {
+                    "key": "/config-env/test/b/d",
+                    "value": "13",
+                    "modifiedIndex": 14,
+                    "createdIndex": 14
+                  }
+                ],
+                "modifiedIndex": 13,
+                "createdIndex": 13
+              },
+              {
+                "key": "/config-env/test/e",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/test/e/f",
+                    "value": "14",
+                    "modifiedIndex": 15,
+                    "createdIndex": 15
+                  },
+                  {
+                    "key": "/config-env/test/e/g",
+                    "dir": true,
+                    "nodes": [
+                      {
+                        "key": "/config-env/test/e/g/h",
+                        "value": "15",
+                        "modifiedIndex": 16,
+                        "createdIndex": 16
+                      }
+                    ],
+                    "modifiedIndex": 16,
+                    "createdIndex": 16
+                  }
+                ],
+                "modifiedIndex": 15,
+                "createdIndex": 15
+              },
+              {
+                "key": "/config-env/test/a",
+                "value": "11",
+                "modifiedIndex": 17,
+                "createdIndex": 17
+              }
+            ],
+            "modifiedIndex": 13,
+            "createdIndex": 13
+          }
+        ],
+        "modifiedIndex": 3,
+        "createdIndex": 3
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "40",
+      "x-raft-index": "6217",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:16:41 GMT",
+      "transfer-encoding": "chunked"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/config-env?recursive=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "get",
+      "node": {
+        "key": "/config-env",
+        "dir": true,
+        "nodes": [
+          {
+            "key": "/config-env/development",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-env/development/b",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/development/b/d",
+                    "value": "3",
+                    "modifiedIndex": 3,
+                    "createdIndex": 3
+                  },
+                  {
+                    "key": "/config-env/development/b/c",
+                    "value": "2",
+                    "modifiedIndex": 4,
+                    "createdIndex": 4
+                  }
+                ],
+                "modifiedIndex": 3,
+                "createdIndex": 3
+              },
+              {
+                "key": "/config-env/development/e",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/development/e/f",
+                    "value": "4",
+                    "modifiedIndex": 5,
+                    "createdIndex": 5
+                  },
+                  {
+                    "key": "/config-env/development/e/g",
+                    "dir": true,
+                    "nodes": [
+                      {
+                        "key": "/config-env/development/e/g/h",
+                        "value": "5",
+                        "modifiedIndex": 6,
+                        "createdIndex": 6
+                      }
+                    ],
+                    "modifiedIndex": 6,
+                    "createdIndex": 6
+                  }
+                ],
+                "modifiedIndex": 5,
+                "createdIndex": 5
+              },
+              {
+                "key": "/config-env/development/a",
+                "value": "1",
+                "modifiedIndex": 7,
+                "createdIndex": 7
+              }
+            ],
+            "modifiedIndex": 3,
+            "createdIndex": 3
+          },
+          {
+            "key": "/config-env/production",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-env/production/e",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/production/e/g",
+                    "dir": true,
+                    "nodes": [
+                      {
+                        "key": "/config-env/production/e/g/h",
+                        "value": "10",
+                        "modifiedIndex": 8,
+                        "createdIndex": 8
+                      }
+                    ],
+                    "modifiedIndex": 8,
+                    "createdIndex": 8
+                  },
+                  {
+                    "key": "/config-env/production/e/f",
+                    "value": "9",
+                    "modifiedIndex": 12,
+                    "createdIndex": 12
+                  }
+                ],
+                "modifiedIndex": 8,
+                "createdIndex": 8
+              },
+              {
+                "key": "/config-env/production/a",
+                "value": "6",
+                "modifiedIndex": 9,
+                "createdIndex": 9
+              },
+              {
+                "key": "/config-env/production/b",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/production/b/d",
+                    "value": "8",
+                    "modifiedIndex": 10,
+                    "createdIndex": 10
+                  },
+                  {
+                    "key": "/config-env/production/b/c",
+                    "value": "7",
+                    "modifiedIndex": 11,
+                    "createdIndex": 11
+                  }
+                ],
+                "modifiedIndex": 10,
+                "createdIndex": 10
+              }
+            ],
+            "modifiedIndex": 8,
+            "createdIndex": 8
+          },
+          {
+            "key": "/config-env/test",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-env/test/b",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/test/b/c",
+                    "value": "12",
+                    "modifiedIndex": 13,
+                    "createdIndex": 13
+                  },
+                  {
+                    "key": "/config-env/test/b/d",
+                    "value": "13",
+                    "modifiedIndex": 14,
+                    "createdIndex": 14
+                  }
+                ],
+                "modifiedIndex": 13,
+                "createdIndex": 13
+              },
+              {
+                "key": "/config-env/test/e",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/test/e/f",
+                    "value": "14",
+                    "modifiedIndex": 15,
+                    "createdIndex": 15
+                  },
+                  {
+                    "key": "/config-env/test/e/g",
+                    "dir": true,
+                    "nodes": [
+                      {
+                        "key": "/config-env/test/e/g/h",
+                        "value": "15",
+                        "modifiedIndex": 16,
+                        "createdIndex": 16
+                      }
+                    ],
+                    "modifiedIndex": 16,
+                    "createdIndex": 16
+                  }
+                ],
+                "modifiedIndex": 15,
+                "createdIndex": 15
+              },
+              {
+                "key": "/config-env/test/a",
+                "value": "11",
+                "modifiedIndex": 17,
+                "createdIndex": 17
+              }
+            ],
+            "modifiedIndex": 13,
+            "createdIndex": 13
+          }
+        ],
+        "modifiedIndex": 3,
+        "createdIndex": 3
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "40",
+      "x-raft-index": "6217",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:16:41 GMT",
+      "transfer-encoding": "chunked"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/configs1?recursive=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "get",
+      "node": {
+        "key": "/configs1",
+        "dir": true,
+        "nodes": [
+          {
+            "key": "/configs1/a",
+            "value": "1",
+            "modifiedIndex": 24,
+            "createdIndex": 24
+          },
+          {
+            "key": "/configs1/b",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/configs1/b/c",
+                "value": "1",
+                "modifiedIndex": 25,
+                "createdIndex": 25
+              },
+              {
+                "key": "/configs1/b/d",
+                "value": "2",
+                "modifiedIndex": 39,
+                "createdIndex": 39
+              }
+            ],
+            "modifiedIndex": 25,
+            "createdIndex": 25
+          },
+          {
+            "key": "/configs1/e",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/configs1/e/f",
+                "value": "3",
+                "modifiedIndex": 27,
+                "createdIndex": 27
+              },
+              {
+                "key": "/configs1/e/g",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/configs1/e/g/h",
+                    "value": "4",
+                    "modifiedIndex": 28,
+                    "createdIndex": 28
+                  }
+                ],
+                "modifiedIndex": 28,
+                "createdIndex": 28
+              }
+            ],
+            "modifiedIndex": 27,
+            "createdIndex": 27
+          }
+        ],
+        "modifiedIndex": 24,
+        "createdIndex": 24
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "40",
+      "x-raft-index": "6217",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:16:41 GMT",
+      "content-length": "709"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/configs2?recursive=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "get",
+      "node": {
+        "key": "/configs2",
+        "dir": true,
+        "nodes": [
+          {
+            "key": "/configs2/i",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/configs2/i/j",
+                "value": "5",
+                "modifiedIndex": 30,
+                "createdIndex": 30
+              },
+              {
+                "key": "/configs2/i/k",
+                "value": "6",
+                "modifiedIndex": 31,
+                "createdIndex": 31
+              }
+            ],
+            "modifiedIndex": 30,
+            "createdIndex": 30
+          },
+          {
+            "key": "/configs2/l",
+            "value": "7",
+            "modifiedIndex": 32,
+            "createdIndex": 32
+          },
+          {
+            "key": "/configs2/b",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/configs2/b/c",
+                "value": "2",
+                "modifiedIndex": 29,
+                "createdIndex": 29
+              }
+            ],
+            "modifiedIndex": 29,
+            "createdIndex": 29
+          }
+        ],
+        "modifiedIndex": 29,
+        "createdIndex": 29
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "40",
+      "x-raft-index": "6217",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:16:41 GMT",
+      "content-length": "552"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/config-env?recursive=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "get",
+      "node": {
+        "key": "/config-env",
+        "dir": true,
+        "nodes": [
+          {
+            "key": "/config-env/development",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-env/development/b",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/development/b/d",
+                    "value": "3",
+                    "modifiedIndex": 3,
+                    "createdIndex": 3
+                  },
+                  {
+                    "key": "/config-env/development/b/c",
+                    "value": "2",
+                    "modifiedIndex": 4,
+                    "createdIndex": 4
+                  }
+                ],
+                "modifiedIndex": 3,
+                "createdIndex": 3
+              },
+              {
+                "key": "/config-env/development/e",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/development/e/f",
+                    "value": "4",
+                    "modifiedIndex": 5,
+                    "createdIndex": 5
+                  },
+                  {
+                    "key": "/config-env/development/e/g",
+                    "dir": true,
+                    "nodes": [
+                      {
+                        "key": "/config-env/development/e/g/h",
+                        "value": "5",
+                        "modifiedIndex": 6,
+                        "createdIndex": 6
+                      }
+                    ],
+                    "modifiedIndex": 6,
+                    "createdIndex": 6
+                  }
+                ],
+                "modifiedIndex": 5,
+                "createdIndex": 5
+              },
+              {
+                "key": "/config-env/development/a",
+                "value": "1",
+                "modifiedIndex": 7,
+                "createdIndex": 7
+              }
+            ],
+            "modifiedIndex": 3,
+            "createdIndex": 3
+          },
+          {
+            "key": "/config-env/production",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-env/production/e",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/production/e/g",
+                    "dir": true,
+                    "nodes": [
+                      {
+                        "key": "/config-env/production/e/g/h",
+                        "value": "10",
+                        "modifiedIndex": 8,
+                        "createdIndex": 8
+                      }
+                    ],
+                    "modifiedIndex": 8,
+                    "createdIndex": 8
+                  },
+                  {
+                    "key": "/config-env/production/e/f",
+                    "value": "9",
+                    "modifiedIndex": 12,
+                    "createdIndex": 12
+                  }
+                ],
+                "modifiedIndex": 8,
+                "createdIndex": 8
+              },
+              {
+                "key": "/config-env/production/a",
+                "value": "6",
+                "modifiedIndex": 9,
+                "createdIndex": 9
+              },
+              {
+                "key": "/config-env/production/b",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/production/b/d",
+                    "value": "8",
+                    "modifiedIndex": 10,
+                    "createdIndex": 10
+                  },
+                  {
+                    "key": "/config-env/production/b/c",
+                    "value": "7",
+                    "modifiedIndex": 11,
+                    "createdIndex": 11
+                  }
+                ],
+                "modifiedIndex": 10,
+                "createdIndex": 10
+              }
+            ],
+            "modifiedIndex": 8,
+            "createdIndex": 8
+          },
+          {
+            "key": "/config-env/test",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-env/test/a",
+                "value": "11",
+                "modifiedIndex": 17,
+                "createdIndex": 17
+              },
+              {
+                "key": "/config-env/test/b",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/test/b/c",
+                    "value": "12",
+                    "modifiedIndex": 13,
+                    "createdIndex": 13
+                  },
+                  {
+                    "key": "/config-env/test/b/d",
+                    "value": "13",
+                    "modifiedIndex": 14,
+                    "createdIndex": 14
+                  }
+                ],
+                "modifiedIndex": 13,
+                "createdIndex": 13
+              },
+              {
+                "key": "/config-env/test/e",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/test/e/g",
+                    "dir": true,
+                    "nodes": [
+                      {
+                        "key": "/config-env/test/e/g/h",
+                        "value": "15",
+                        "modifiedIndex": 16,
+                        "createdIndex": 16
+                      }
+                    ],
+                    "modifiedIndex": 16,
+                    "createdIndex": 16
+                  },
+                  {
+                    "key": "/config-env/test/e/f",
+                    "value": "14",
+                    "modifiedIndex": 15,
+                    "createdIndex": 15
+                  }
+                ],
+                "modifiedIndex": 15,
+                "createdIndex": 15
+              }
+            ],
+            "modifiedIndex": 13,
+            "createdIndex": 13
+          }
+        ],
+        "modifiedIndex": 3,
+        "createdIndex": 3
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "40",
+      "x-raft-index": "6217",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:16:41 GMT",
+      "transfer-encoding": "chunked"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/config-env?recursive=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "get",
+      "node": {
+        "key": "/config-env",
+        "dir": true,
+        "nodes": [
+          {
+            "key": "/config-env/development",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-env/development/b",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/development/b/d",
+                    "value": "3",
+                    "modifiedIndex": 3,
+                    "createdIndex": 3
+                  },
+                  {
+                    "key": "/config-env/development/b/c",
+                    "value": "2",
+                    "modifiedIndex": 4,
+                    "createdIndex": 4
+                  }
+                ],
+                "modifiedIndex": 3,
+                "createdIndex": 3
+              },
+              {
+                "key": "/config-env/development/e",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/development/e/f",
+                    "value": "4",
+                    "modifiedIndex": 5,
+                    "createdIndex": 5
+                  },
+                  {
+                    "key": "/config-env/development/e/g",
+                    "dir": true,
+                    "nodes": [
+                      {
+                        "key": "/config-env/development/e/g/h",
+                        "value": "5",
+                        "modifiedIndex": 6,
+                        "createdIndex": 6
+                      }
+                    ],
+                    "modifiedIndex": 6,
+                    "createdIndex": 6
+                  }
+                ],
+                "modifiedIndex": 5,
+                "createdIndex": 5
+              },
+              {
+                "key": "/config-env/development/a",
+                "value": "1",
+                "modifiedIndex": 7,
+                "createdIndex": 7
+              }
+            ],
+            "modifiedIndex": 3,
+            "createdIndex": 3
+          },
+          {
+            "key": "/config-env/production",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-env/production/e",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/production/e/f",
+                    "value": "9",
+                    "modifiedIndex": 12,
+                    "createdIndex": 12
+                  },
+                  {
+                    "key": "/config-env/production/e/g",
+                    "dir": true,
+                    "nodes": [
+                      {
+                        "key": "/config-env/production/e/g/h",
+                        "value": "10",
+                        "modifiedIndex": 8,
+                        "createdIndex": 8
+                      }
+                    ],
+                    "modifiedIndex": 8,
+                    "createdIndex": 8
+                  }
+                ],
+                "modifiedIndex": 8,
+                "createdIndex": 8
+              },
+              {
+                "key": "/config-env/production/a",
+                "value": "6",
+                "modifiedIndex": 9,
+                "createdIndex": 9
+              },
+              {
+                "key": "/config-env/production/b",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/production/b/d",
+                    "value": "8",
+                    "modifiedIndex": 10,
+                    "createdIndex": 10
+                  },
+                  {
+                    "key": "/config-env/production/b/c",
+                    "value": "7",
+                    "modifiedIndex": 11,
+                    "createdIndex": 11
+                  }
+                ],
+                "modifiedIndex": 10,
+                "createdIndex": 10
+              }
+            ],
+            "modifiedIndex": 8,
+            "createdIndex": 8
+          },
+          {
+            "key": "/config-env/test",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-env/test/b",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/test/b/c",
+                    "value": "12",
+                    "modifiedIndex": 13,
+                    "createdIndex": 13
+                  },
+                  {
+                    "key": "/config-env/test/b/d",
+                    "value": "13",
+                    "modifiedIndex": 14,
+                    "createdIndex": 14
+                  }
+                ],
+                "modifiedIndex": 13,
+                "createdIndex": 13
+              },
+              {
+                "key": "/config-env/test/e",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/test/e/f",
+                    "value": "14",
+                    "modifiedIndex": 15,
+                    "createdIndex": 15
+                  },
+                  {
+                    "key": "/config-env/test/e/g",
+                    "dir": true,
+                    "nodes": [
+                      {
+                        "key": "/config-env/test/e/g/h",
+                        "value": "15",
+                        "modifiedIndex": 16,
+                        "createdIndex": 16
+                      }
+                    ],
+                    "modifiedIndex": 16,
+                    "createdIndex": 16
+                  }
+                ],
+                "modifiedIndex": 15,
+                "createdIndex": 15
+              },
+              {
+                "key": "/config-env/test/a",
+                "value": "11",
+                "modifiedIndex": 17,
+                "createdIndex": 17
+              }
+            ],
+            "modifiedIndex": 13,
+            "createdIndex": 13
+          }
+        ],
+        "modifiedIndex": 3,
+        "createdIndex": 3
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "40",
+      "x-raft-index": "6217",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:16:41 GMT",
+      "transfer-encoding": "chunked"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/config-env?recursive=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "get",
+      "node": {
+        "key": "/config-env",
+        "dir": true,
+        "nodes": [
+          {
+            "key": "/config-env/development",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-env/development/b",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/development/b/d",
+                    "value": "3",
+                    "modifiedIndex": 3,
+                    "createdIndex": 3
+                  },
+                  {
+                    "key": "/config-env/development/b/c",
+                    "value": "2",
+                    "modifiedIndex": 4,
+                    "createdIndex": 4
+                  }
+                ],
+                "modifiedIndex": 3,
+                "createdIndex": 3
+              },
+              {
+                "key": "/config-env/development/e",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/development/e/f",
+                    "value": "4",
+                    "modifiedIndex": 5,
+                    "createdIndex": 5
+                  },
+                  {
+                    "key": "/config-env/development/e/g",
+                    "dir": true,
+                    "nodes": [
+                      {
+                        "key": "/config-env/development/e/g/h",
+                        "value": "5",
+                        "modifiedIndex": 6,
+                        "createdIndex": 6
+                      }
+                    ],
+                    "modifiedIndex": 6,
+                    "createdIndex": 6
+                  }
+                ],
+                "modifiedIndex": 5,
+                "createdIndex": 5
+              },
+              {
+                "key": "/config-env/development/a",
+                "value": "1",
+                "modifiedIndex": 7,
+                "createdIndex": 7
+              }
+            ],
+            "modifiedIndex": 3,
+            "createdIndex": 3
+          },
+          {
+            "key": "/config-env/production",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-env/production/e",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/production/e/g",
+                    "dir": true,
+                    "nodes": [
+                      {
+                        "key": "/config-env/production/e/g/h",
+                        "value": "10",
+                        "modifiedIndex": 8,
+                        "createdIndex": 8
+                      }
+                    ],
+                    "modifiedIndex": 8,
+                    "createdIndex": 8
+                  },
+                  {
+                    "key": "/config-env/production/e/f",
+                    "value": "9",
+                    "modifiedIndex": 12,
+                    "createdIndex": 12
+                  }
+                ],
+                "modifiedIndex": 8,
+                "createdIndex": 8
+              },
+              {
+                "key": "/config-env/production/a",
+                "value": "6",
+                "modifiedIndex": 9,
+                "createdIndex": 9
+              },
+              {
+                "key": "/config-env/production/b",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/production/b/d",
+                    "value": "8",
+                    "modifiedIndex": 10,
+                    "createdIndex": 10
+                  },
+                  {
+                    "key": "/config-env/production/b/c",
+                    "value": "7",
+                    "modifiedIndex": 11,
+                    "createdIndex": 11
+                  }
+                ],
+                "modifiedIndex": 10,
+                "createdIndex": 10
+              }
+            ],
+            "modifiedIndex": 8,
+            "createdIndex": 8
+          },
+          {
+            "key": "/config-env/test",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-env/test/b",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/test/b/c",
+                    "value": "12",
+                    "modifiedIndex": 13,
+                    "createdIndex": 13
+                  },
+                  {
+                    "key": "/config-env/test/b/d",
+                    "value": "13",
+                    "modifiedIndex": 14,
+                    "createdIndex": 14
+                  }
+                ],
+                "modifiedIndex": 13,
+                "createdIndex": 13
+              },
+              {
+                "key": "/config-env/test/e",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/config-env/test/e/f",
+                    "value": "14",
+                    "modifiedIndex": 15,
+                    "createdIndex": 15
+                  },
+                  {
+                    "key": "/config-env/test/e/g",
+                    "dir": true,
+                    "nodes": [
+                      {
+                        "key": "/config-env/test/e/g/h",
+                        "value": "15",
+                        "modifiedIndex": 16,
+                        "createdIndex": 16
+                      }
+                    ],
+                    "modifiedIndex": 16,
+                    "createdIndex": 16
+                  }
+                ],
+                "modifiedIndex": 15,
+                "createdIndex": 15
+              },
+              {
+                "key": "/config-env/test/a",
+                "value": "11",
+                "modifiedIndex": 17,
+                "createdIndex": 17
+              }
+            ],
+            "modifiedIndex": 13,
+            "createdIndex": 13
+          }
+        ],
+        "modifiedIndex": 3,
+        "createdIndex": 3
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "40",
+      "x-raft-index": "6217",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:16:41 GMT",
+      "transfer-encoding": "chunked"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/config-shared-env?recursive=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "get",
+      "node": {
+        "key": "/config-shared-env",
+        "dir": true,
+        "nodes": [
+          {
+            "key": "/config-shared-env/test",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-shared-env/test/b",
+                "value": "4",
+                "modifiedIndex": 18,
+                "createdIndex": 18
+              }
+            ],
+            "modifiedIndex": 18,
+            "createdIndex": 18
+          },
+          {
+            "key": "/config-shared-env/production",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-shared-env/production/c",
+                "value": "4",
+                "modifiedIndex": 19,
+                "createdIndex": 19
+              }
+            ],
+            "modifiedIndex": 19,
+            "createdIndex": 19
+          },
+          {
+            "key": "/config-shared-env/*",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-shared-env/*/a",
+                "value": "1",
+                "modifiedIndex": 20,
+                "createdIndex": 20
+              },
+              {
+                "key": "/config-shared-env/*/b",
+                "value": "2",
+                "modifiedIndex": 21,
+                "createdIndex": 21
+              }
+            ],
+            "modifiedIndex": 20,
+            "createdIndex": 20
+          },
+          {
+            "key": "/config-shared-env/development",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-shared-env/development/c",
+                "value": "4",
+                "modifiedIndex": 23,
+                "createdIndex": 23
+              },
+              {
+                "key": "/config-shared-env/development/b",
+                "value": "3",
+                "modifiedIndex": 22,
+                "createdIndex": 22
+              }
+            ],
+            "modifiedIndex": 22,
+            "createdIndex": 22
+          }
+        ],
+        "modifiedIndex": 18,
+        "createdIndex": 18
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "40",
+      "x-raft-index": "6217",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:16:41 GMT",
+      "content-length": "1013"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/config-shared-env?recursive=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "get",
+      "node": {
+        "key": "/config-shared-env",
+        "dir": true,
+        "nodes": [
+          {
+            "key": "/config-shared-env/production",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-shared-env/production/c",
+                "value": "4",
+                "modifiedIndex": 19,
+                "createdIndex": 19
+              }
+            ],
+            "modifiedIndex": 19,
+            "createdIndex": 19
+          },
+          {
+            "key": "/config-shared-env/*",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-shared-env/*/a",
+                "value": "1",
+                "modifiedIndex": 20,
+                "createdIndex": 20
+              },
+              {
+                "key": "/config-shared-env/*/b",
+                "value": "2",
+                "modifiedIndex": 21,
+                "createdIndex": 21
+              }
+            ],
+            "modifiedIndex": 20,
+            "createdIndex": 20
+          },
+          {
+            "key": "/config-shared-env/development",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-shared-env/development/c",
+                "value": "4",
+                "modifiedIndex": 23,
+                "createdIndex": 23
+              },
+              {
+                "key": "/config-shared-env/development/b",
+                "value": "3",
+                "modifiedIndex": 22,
+                "createdIndex": 22
+              }
+            ],
+            "modifiedIndex": 22,
+            "createdIndex": 22
+          },
+          {
+            "key": "/config-shared-env/test",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-shared-env/test/b",
+                "value": "4",
+                "modifiedIndex": 18,
+                "createdIndex": 18
+              }
+            ],
+            "modifiedIndex": 18,
+            "createdIndex": 18
+          }
+        ],
+        "modifiedIndex": 18,
+        "createdIndex": 18
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "40",
+      "x-raft-index": "6217",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:16:41 GMT",
+      "content-length": "1013"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/config-shared-env?recursive=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "get",
+      "node": {
+        "key": "/config-shared-env",
+        "dir": true,
+        "nodes": [
+          {
+            "key": "/config-shared-env/test",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-shared-env/test/b",
+                "value": "4",
+                "modifiedIndex": 18,
+                "createdIndex": 18
+              }
+            ],
+            "modifiedIndex": 18,
+            "createdIndex": 18
+          },
+          {
+            "key": "/config-shared-env/production",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-shared-env/production/c",
+                "value": "4",
+                "modifiedIndex": 19,
+                "createdIndex": 19
+              }
+            ],
+            "modifiedIndex": 19,
+            "createdIndex": 19
+          },
+          {
+            "key": "/config-shared-env/*",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-shared-env/*/a",
+                "value": "1",
+                "modifiedIndex": 20,
+                "createdIndex": 20
+              },
+              {
+                "key": "/config-shared-env/*/b",
+                "value": "2",
+                "modifiedIndex": 21,
+                "createdIndex": 21
+              }
+            ],
+            "modifiedIndex": 20,
+            "createdIndex": 20
+          },
+          {
+            "key": "/config-shared-env/development",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/config-shared-env/development/b",
+                "value": "3",
+                "modifiedIndex": 22,
+                "createdIndex": 22
+              },
+              {
+                "key": "/config-shared-env/development/c",
+                "value": "4",
+                "modifiedIndex": 23,
+                "createdIndex": 23
+              }
+            ],
+            "modifiedIndex": 22,
+            "createdIndex": 22
+          }
+        ],
+        "modifiedIndex": 18,
+        "createdIndex": 18
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "40",
+      "x-raft-index": "6217",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:16:41 GMT",
+      "content-length": "1013"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/configs1?recursive=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "get",
+      "node": {
+        "key": "/configs1",
+        "dir": true,
+        "nodes": [
+          {
+            "key": "/configs1/a",
+            "value": "1",
+            "modifiedIndex": 24,
+            "createdIndex": 24
+          },
+          {
+            "key": "/configs1/b",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/configs1/b/c",
+                "value": "1",
+                "modifiedIndex": 25,
+                "createdIndex": 25
+              },
+              {
+                "key": "/configs1/b/d",
+                "value": "2",
+                "modifiedIndex": 39,
+                "createdIndex": 39
+              }
+            ],
+            "modifiedIndex": 25,
+            "createdIndex": 25
+          },
+          {
+            "key": "/configs1/e",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/configs1/e/g",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/configs1/e/g/h",
+                    "value": "4",
+                    "modifiedIndex": 28,
+                    "createdIndex": 28
+                  }
+                ],
+                "modifiedIndex": 28,
+                "createdIndex": 28
+              },
+              {
+                "key": "/configs1/e/f",
+                "value": "3",
+                "modifiedIndex": 27,
+                "createdIndex": 27
+              }
+            ],
+            "modifiedIndex": 27,
+            "createdIndex": 27
+          }
+        ],
+        "modifiedIndex": 24,
+        "createdIndex": 24
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "40",
+      "x-raft-index": "6218",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:16:42 GMT",
+      "content-length": "709"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/configs1?recursive=true&wait=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "set",
+      "node": {
+        "key": "/configs1/a",
+        "value": "4",
+        "modifiedIndex": 41,
+        "createdIndex": 41
+      },
+      "prevNode": {
+        "key": "/configs1/a",
+        "value": "1",
+        "modifiedIndex": 24,
+        "createdIndex": 24
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "40",
+      "x-raft-index": "6218",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:16:42 GMT",
+      "transfer-encoding": "chunked"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/configs1?recursive=true&wait=true&waitIndex=42",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "set",
+      "node": {
+        "key": "/configs1/b/c",
+        "value": "5",
+        "modifiedIndex": 42,
+        "createdIndex": 42
+      },
+      "prevNode": {
+        "key": "/configs1/b/c",
+        "value": "1",
+        "modifiedIndex": 25,
+        "createdIndex": 25
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "41",
+      "x-raft-index": "6262",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:17:03 GMT",
+      "transfer-encoding": "chunked"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/configs1?recursive=true&wait=true&waitIndex=43",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "set",
+      "node": {
+        "key": "/configs1/b/d",
+        "value": "7",
+        "modifiedIndex": 43,
+        "createdIndex": 43
+      },
+      "prevNode": {
+        "key": "/configs1/b/d",
+        "value": "2",
+        "modifiedIndex": 39,
+        "createdIndex": 39
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "42",
+      "x-raft-index": "6284",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:17:14 GMT",
+      "transfer-encoding": "chunked"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/configs1?recursive=true&wait=true&waitIndex=44",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "set",
+      "node": {
+        "key": "/configs1/e/g/h",
+        "value": "9",
+        "modifiedIndex": 44,
+        "createdIndex": 44
+      },
+      "prevNode": {
+        "key": "/configs1/e/g/h",
+        "value": "4",
+        "modifiedIndex": 28,
+        "createdIndex": 28
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "43",
+      "x-raft-index": "6300",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:17:22 GMT",
+      "transfer-encoding": "chunked"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/configs1?recursive=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "get",
+      "node": {
+        "key": "/configs1",
+        "dir": true,
+        "nodes": [
+          {
+            "key": "/configs1/a",
+            "value": "1",
+            "modifiedIndex": 24,
+            "createdIndex": 24
+          },
+          {
+            "key": "/configs1/b",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/configs1/b/c",
+                "value": "1",
+                "modifiedIndex": 25,
+                "createdIndex": 25
+              },
+              {
+                "key": "/configs1/b/d",
+                "value": "2",
+                "modifiedIndex": 39,
+                "createdIndex": 39
+              }
+            ],
+            "modifiedIndex": 25,
+            "createdIndex": 25
+          },
+          {
+            "key": "/configs1/e",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/configs1/e/g",
+                "dir": true,
+                "nodes": [
+                  {
+                    "key": "/configs1/e/g/h",
+                    "value": "4",
+                    "modifiedIndex": 28,
+                    "createdIndex": 28
+                  }
+                ],
+                "modifiedIndex": 28,
+                "createdIndex": 28
+              },
+              {
+                "key": "/configs1/e/f",
+                "value": "3",
+                "modifiedIndex": 27,
+                "createdIndex": 27
+              }
+            ],
+            "modifiedIndex": 27,
+            "createdIndex": 27
+          }
+        ],
+        "modifiedIndex": 24,
+        "createdIndex": 24
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "40",
+      "x-raft-index": "6218",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:16:42 GMT",
+      "content-length": "709"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/configs1?recursive=true&wait=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "set",
+      "node": {
+        "key": "/configs1/a",
+        "value": "4",
+        "modifiedIndex": 41,
+        "createdIndex": 41
+      },
+      "prevNode": {
+        "key": "/configs1/a",
+        "value": "1",
+        "modifiedIndex": 24,
+        "createdIndex": 24
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "40",
+      "x-raft-index": "6218",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:16:42 GMT",
+      "transfer-encoding": "chunked"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/configs1?recursive=true&wait=true&waitIndex=42",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "set",
+      "node": {
+        "key": "/configs1/b/c",
+        "value": "5",
+        "modifiedIndex": 42,
+        "createdIndex": 42
+      },
+      "prevNode": {
+        "key": "/configs1/b/c",
+        "value": "1",
+        "modifiedIndex": 25,
+        "createdIndex": 25
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "41",
+      "x-raft-index": "6262",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:17:03 GMT",
+      "transfer-encoding": "chunked"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/configs1?recursive=true&wait=true&waitIndex=43",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "set",
+      "node": {
+        "key": "/configs1/b/d",
+        "value": "7",
+        "modifiedIndex": 43,
+        "createdIndex": 43
+      },
+      "prevNode": {
+        "key": "/configs1/b/d",
+        "value": "2",
+        "modifiedIndex": 39,
+        "createdIndex": 39
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "42",
+      "x-raft-index": "6284",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:17:14 GMT",
+      "transfer-encoding": "chunked"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/configs1?recursive=true&wait=true&waitIndex=44",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "set",
+      "node": {
+        "key": "/configs1/e/g/h",
+        "value": "9",
+        "modifiedIndex": 44,
+        "createdIndex": 44
+      },
+      "prevNode": {
+        "key": "/configs1/e/g/h",
+        "value": "4",
+        "modifiedIndex": 28,
+        "createdIndex": 28
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "43",
+      "x-raft-index": "6300",
+      "x-raft-term": "3",
+      "date": "Mon, 16 Mar 2015 22:17:22 GMT",
+      "transfer-encoding": "chunked"
+    }
+  }
+]

--- a/test/config-etcd/queries.json
+++ b/test/config-etcd/queries.json
@@ -1,0 +1,318 @@
+[
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/gruntit?recursive=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "get",
+      "node": {
+        "key": "/gruntit",
+        "dir": true,
+        "nodes": [
+          {
+            "key": "/gruntit/test",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/gruntit/test/b",
+                "value": "4",
+                "modifiedIndex": 22,
+                "createdIndex": 22
+              }
+            ],
+            "modifiedIndex": 7,
+            "createdIndex": 7
+          },
+          {
+            "key": "/gruntit/production",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/gruntit/production/c",
+                "value": "4",
+                "modifiedIndex": 8,
+                "createdIndex": 8
+              }
+            ],
+            "modifiedIndex": 8,
+            "createdIndex": 8
+          },
+          {
+            "key": "/gruntit/*",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/gruntit/*/a",
+                "value": "1",
+                "modifiedIndex": 3,
+                "createdIndex": 3
+              },
+              {
+                "key": "/gruntit/*/b",
+                "value": "2",
+                "modifiedIndex": 4,
+                "createdIndex": 4
+              }
+            ],
+            "modifiedIndex": 3,
+            "createdIndex": 3
+          },
+          {
+            "key": "/gruntit/development",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/gruntit/development/c",
+                "value": "4",
+                "modifiedIndex": 6,
+                "createdIndex": 6
+              },
+              {
+                "key": "/gruntit/development/b",
+                "value": "3",
+                "modifiedIndex": 5,
+                "createdIndex": 5
+              }
+            ],
+            "modifiedIndex": 5,
+            "createdIndex": 5
+          }
+        ],
+        "modifiedIndex": 3,
+        "createdIndex": 3
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "22",
+      "x-raft-index": "3733",
+      "x-raft-term": "2",
+      "date": "Mon, 16 Mar 2015 18:18:24 GMT",
+      "content-length": "883"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/gruntit?recursive=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "get",
+      "node": {
+        "key": "/gruntit",
+        "dir": true,
+        "nodes": [
+          {
+            "key": "/gruntit/development",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/gruntit/development/b",
+                "value": "3",
+                "modifiedIndex": 5,
+                "createdIndex": 5
+              },
+              {
+                "key": "/gruntit/development/c",
+                "value": "4",
+                "modifiedIndex": 6,
+                "createdIndex": 6
+              }
+            ],
+            "modifiedIndex": 5,
+            "createdIndex": 5
+          },
+          {
+            "key": "/gruntit/test",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/gruntit/test/b",
+                "value": "4",
+                "modifiedIndex": 22,
+                "createdIndex": 22
+              }
+            ],
+            "modifiedIndex": 7,
+            "createdIndex": 7
+          },
+          {
+            "key": "/gruntit/production",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/gruntit/production/c",
+                "value": "4",
+                "modifiedIndex": 8,
+                "createdIndex": 8
+              }
+            ],
+            "modifiedIndex": 8,
+            "createdIndex": 8
+          },
+          {
+            "key": "/gruntit/*",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/gruntit/*/a",
+                "value": "1",
+                "modifiedIndex": 3,
+                "createdIndex": 3
+              },
+              {
+                "key": "/gruntit/*/b",
+                "value": "2",
+                "modifiedIndex": 4,
+                "createdIndex": 4
+              }
+            ],
+            "modifiedIndex": 3,
+            "createdIndex": 3
+          }
+        ],
+        "modifiedIndex": 3,
+        "createdIndex": 3
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "22",
+      "x-raft-index": "3733",
+      "x-raft-term": "2",
+      "date": "Mon, 16 Mar 2015 18:18:24 GMT",
+      "content-length": "883"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/gruntit?recursive=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "get",
+      "node": {
+        "key": "/gruntit",
+        "dir": true,
+        "nodes": [
+          {
+            "key": "/gruntit/*",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/gruntit/*/a",
+                "value": "1",
+                "modifiedIndex": 3,
+                "createdIndex": 3
+              },
+              {
+                "key": "/gruntit/*/b",
+                "value": "2",
+                "modifiedIndex": 4,
+                "createdIndex": 4
+              }
+            ],
+            "modifiedIndex": 3,
+            "createdIndex": 3
+          },
+          {
+            "key": "/gruntit/development",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/gruntit/development/b",
+                "value": "3",
+                "modifiedIndex": 5,
+                "createdIndex": 5
+              },
+              {
+                "key": "/gruntit/development/c",
+                "value": "4",
+                "modifiedIndex": 6,
+                "createdIndex": 6
+              }
+            ],
+            "modifiedIndex": 5,
+            "createdIndex": 5
+          },
+          {
+            "key": "/gruntit/test",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/gruntit/test/b",
+                "value": "4",
+                "modifiedIndex": 22,
+                "createdIndex": 22
+              }
+            ],
+            "modifiedIndex": 7,
+            "createdIndex": 7
+          },
+          {
+            "key": "/gruntit/production",
+            "dir": true,
+            "nodes": [
+              {
+                "key": "/gruntit/production/c",
+                "value": "4",
+                "modifiedIndex": 8,
+                "createdIndex": 8
+              }
+            ],
+            "modifiedIndex": 8,
+            "createdIndex": 8
+          }
+        ],
+        "modifiedIndex": 3,
+        "createdIndex": 3
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "22",
+      "x-raft-index": "3743",
+      "x-raft-term": "2",
+      "date": "Mon, 16 Mar 2015 18:18:29 GMT",
+      "content-length": "883"
+    }
+  },
+  {
+    "scope": "http://127.0.0.1:4001",
+    "method": "GET",
+    "path": "/v2/keys/gruntit?recursive=true&wait=true",
+    "body": "",
+    "status": 200,
+    "response": {
+      "action": "set",
+      "node": {
+        "key": "/gruntit/test/b",
+        "value": "2",
+        "modifiedIndex": 23,
+        "createdIndex": 23
+      },
+      "prevNode": {
+        "key": "/gruntit/test/b",
+        "value": "4",
+        "modifiedIndex": 22,
+        "createdIndex": 22
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-etcd-cluster-id": "7e27652122e8b2ae",
+      "x-etcd-index": "22",
+      "x-raft-index": "3743",
+      "x-raft-term": "2",
+      "date": "Mon, 16 Mar 2015 18:18:29 GMT",
+      "transfer-encoding": "chunked"
+    }
+  }
+]

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -33,6 +33,12 @@ it.describe("gofigure.Loader", function (it) {
         assert.equal(loader.fileGlob, path.resolve(__dirname, "./configs/**/*.json"));
     });
 
+    it.should("properly configure the etcd endpoint", function () {
+        var loader = new Loader({endpoints: ["127.0.0.1:4001"], root: "/gruntit"});
+        assert.equal(loader.endpoints[0], ["127.0.0.1:4001"][0]);
+        assert.equal(loader.root, "/gruntit");
+    });
+
 
     it.beforeEach(function () {
         helper.createConfigs();
@@ -57,6 +63,12 @@ it.describe("gofigure.Loader", function (it) {
             assert.deepEqual(loader.config, helper.allDeepMerge());
         });
 
+        /* it.should("load from etcd", function () {
+            var loader = new Loader({endpoints: ["192.168.1.10:4001"], root: "/gruntit"});
+            assert.deepEqual(loader.loadSync(), helper.sharedEnvConf);
+            assert.deepEqual(loader.config, helper.sharedEnvConf);
+        }); */
+
     });
 
     it.describe("#load", function (it) {
@@ -75,6 +87,15 @@ it.describe("gofigure.Loader", function (it) {
                 assert.deepEqual(loader.config, helper.allDeepMerge());
             });
         });
+
+        /* it.should("load from etcd asynchronously", function () {
+            var loader = new Loader({endpoints: ["127.0.0.1:4001"], root: "/gruntit"});
+            return loader.load().then(function (conf) {
+                assert.deepEqual(conf, helper.sharedEnvConf);
+                assert.deepEqual(loader.config, helper.sharedEnvConf);
+            });
+        }); */
+
     });
 
     it.describe("#watch", function (it) {


### PR DESCRIPTION
All work to date for Etcd support in Gofigure.  The following issues remain though:

* Supported Node.js version is 0.10 or greater. This is covered in the readme though Travis would need to be updated.
* I started work on tests for Etcd.  Unfortunately, the way that the node-etcd module does synchronous support isn't getting into an infinite loop when running the test commented out.  I found it is an issue with the version of promise-extend and bumping it to 0.0.9 fixes the test.  I can bump the version if that's ok.

- [x] @doug-martin - Doug Martin