### PR TITLE
v2.0.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,14 @@
+# v2.0.0
+
+* [FIX] Incorrect type in jsdoc comment - [#25](https://github.com/C2FO/gofigure/pull/25) - [@NLincoln](https://github.com/NLincoln)
+* [CHORE] Bump `glob` version to `^v7.1.7`
+* [CHORE] Bump `lodash` version to `^v4.17.21`
+* [CHORE] Bump `eslint` version to `v7.27.0`
+* [CHORE] Update supported node version to `>v12`
+* [CHORE] Introduce `prettier`
+* [CHORE] Migrate to github actions
+* [CHORE] Migrate to `jest`
+
 # v1.0.0
 
 * Add env variable support

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gofigure",
   "description": "Configuration library for node",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "scripts": {
     "jest": "jest --runInBand",
     "test": "npm run eslint && npm run jest",


### PR DESCRIPTION
* [FIX] Incorrect type in jsdoc comment - #25 - @NLincoln
* [CHORE] Bump `glob` version to `^v7.1.7`
* [CHORE] Bump `lodash` version to `^v4.17.21`
* [CHORE] Bump `eslint` version to `v7.27.0`
* [CHORE] Update supported node version to `>v12`
* [CHORE] Introduce `prettier`
* [CHORE] Migrate to github actions
* [CHORE] Migrate to `jest`