### PR TITLE
fix: select env after merging all files together

### DIFF
--- a/lib/ConfigLocation.js
+++ b/lib/ConfigLocation.js
@@ -60,7 +60,7 @@ class ConfigLocation extends PatternEventEmitter {
     if (this.__loaded) {
       return Promise.resolve(this.config);
     }
-    return loader.createLoadersAsync({ locations: [this.locationName] }, { monitor: this.monitor }).then((loaders) => {
+    return loader.createLoadersAsync(this.locationName, { monitor: this.monitor }).then((loaders) => {
       this.__loaders = loaders;
       const loads = loaders.map((l) => l.load());
       return Promise.all(loads).then((configs) => this.__postLoad(configs));
@@ -80,7 +80,7 @@ class ConfigLocation extends PatternEventEmitter {
     if (this.__loaded) {
       return this.config;
     }
-    this.__loaders = loader.createLoadersSync({ locations: [this.locationName] }, { monitor: this.monitor });
+    this.__loaders = loader.createLoadersSync(this.locationName, { monitor: this.monitor });
     return this.__postLoad(this.__loaders.map((l) => l.loadSync()));
   }
 

--- a/lib/ConfigLocation.js
+++ b/lib/ConfigLocation.js
@@ -16,6 +16,9 @@ class ConfigLocation extends PatternEventEmitter {
    *
    * Locations will load all the config files specified within their list
    * and then merge them together.
+   *
+   * @param {{ file: string }} locationName the location that this instance should own
+   * @param opts @see ConfigLoader
    */
   constructor(locationName, opts) {
     super({});
@@ -107,7 +110,17 @@ class ConfigLocation extends PatternEventEmitter {
   __listenToChanges() {
     this.__loaders.forEach((l) =>
       l.on('change', (path, config) => {
-        this.emit('change', this.__mergeConfigs([config]));
+        /**
+         * Whenever one of our loaders reports that their file was changed,
+         * we forward that event onward.
+         *
+         * The `config` object here is just the raw contents of the file. Our "parent"
+         * listener expects us to forward them the resolved config, so we process it before
+         * forwarding it.
+         */
+        this.config = this.__mergeConfigs([config]);
+
+        this.emit('change', this.config);
       }),
     );
   }

--- a/lib/ConfigLocation.js
+++ b/lib/ConfigLocation.js
@@ -1,0 +1,116 @@
+/**
+ * @projectName gofigure
+ * @github http://github.com/C2FO/gofigure
+ * @header [../README.md]
+ * @includeDoc [Change Log] ../History.md
+ */
+
+const _ = require('lodash');
+const PatternEventEmitter = require('./PatternEventEmitter');
+const loader = require('./loader');
+const processor = require('./processor');
+
+class ConfigLocation extends PatternEventEmitter {
+  /**
+   * Aggregate class for a single entry in the `locations` array.
+   *
+   * Locations will load all the config files specified within their list
+   * and then merge them together.
+   */
+  constructor(locationName, opts) {
+    super({});
+    if (!locationName) {
+      throw new Error('A locationName is required');
+    }
+    const options = opts || {};
+    this.environment = options.environment || process.env.NODE_ENV || null;
+    this.nodeType = options.nodeType || process.env.NODE_TYPE || null;
+    this.environmentVariables = options.environmentVariables || process.env || {};
+    this.defaultEnvironment = options.defaultEnvironment || '*';
+    this.config = {};
+    this.monitor = !!options.monitor;
+    this.locationName = locationName;
+    this.loaded = false;
+  }
+
+  /**
+   * Stops monitoring confgurations for changes.
+   *
+   * @return {Config} this config object.
+   */
+  stop() {
+    this.__loaders.forEach((l) => l.unWatch());
+    return this;
+  }
+
+  /**
+   * Asynchronously loads configs.
+   *
+   * @example
+   * configLoader.load().then((config) => {
+   *     // use the config.
+   * })
+   *
+   * @return {Promise<any>|Promise<any[] | never>} resolves with the merged configuration from all locations.s
+   */
+  load() {
+    if (this.__loaded) {
+      return Promise.resolve(this.config);
+    }
+    return loader.createLoadersAsync({ locations: [this.locationName] }, { monitor: this.monitor }).then((loaders) => {
+      this.__loaders = loaders;
+      const loads = loaders.map((l) => l.load());
+      return Promise.all(loads).then((configs) => this.__postLoad(configs));
+    });
+  }
+
+  /**
+   * Synchronously loads configurations.
+   *
+   * @example
+   * const config = configLoader.loadSync()
+   * //use your config.
+   *
+   * @return {Object} the merged configuration from all locations.
+   */
+  loadSync() {
+    if (this.__loaded) {
+      return this.config;
+    }
+    this.__loaders = loader.createLoadersSync({ locations: [this.locationName] }, { monitor: this.monitor });
+    return this.__postLoad(this.__loaders.map((l) => l.loadSync()));
+  }
+
+  __mergeConfigs(configs) {
+    return processor(_.cloneDeep(this.config), configs, {
+      environment: this.environment,
+      defaultEnvironment: this.defaultEnvironment,
+      nodeType: this.nodeType,
+      eventEmitter: this,
+      environmentVariables: this.environmentVariables,
+    });
+  }
+
+  /**
+   *  Merges configs and starts monitoring of configs if `monitor` is true.
+   * @param configs {Array<Object>} an array of configurations to merge into a single object.
+   * @return {Object} the merged config
+   * @private
+   */
+  __postLoad(configs) {
+    this.config = this.__mergeConfigs(configs);
+    this.__listenToChanges();
+    this.__loaded = true;
+    return this.config;
+  }
+
+  __listenToChanges() {
+    this.__loaders.forEach((l) =>
+      l.on('change', (path, config) => {
+        this.emit('change', this.__mergeConfigs([config]));
+      }),
+    );
+  }
+}
+
+module.exports = ConfigLocation;

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,8 +7,8 @@
 
 const _ = require('lodash');
 const PatternEventEmitter = require('./PatternEventEmitter');
-const loader = require('./loader');
-const processor = require('./processor');
+const ConfigLocation = require('./ConfigLocation');
+const merger = require('./processor/merger');
 
 class ConfigLoader extends PatternEventEmitter {
   /**
@@ -37,6 +37,8 @@ class ConfigLoader extends PatternEventEmitter {
     this.monitor = !!options.monitor;
     this.loaderConfig = loaderConfig;
     this.loaded = false;
+
+    this.locations = loaderConfig.locations.map((locationName) => new ConfigLocation(locationName, opts));
   }
 
   /**
@@ -45,7 +47,7 @@ class ConfigLoader extends PatternEventEmitter {
    * @return {Config} this config object.
    */
   stop() {
-    this.__loaders.forEach((l) => l.unWatch());
+    this.locations.forEach((l) => l.stop());
     return this;
   }
 
@@ -63,10 +65,8 @@ class ConfigLoader extends PatternEventEmitter {
     if (this.__loaded) {
       return Promise.resolve(this.config);
     }
-    return loader.createLoadersAsync(this.loaderConfig, { monitor: this.monitor }).then((loaders) => {
-      this.__loaders = loaders;
-      const loads = loaders.map((l) => l.load());
-      return Promise.all(loads).then((configs) => this.__postLoad(configs));
+    return Promise.all(this.locations.map((location) => location.load())).then((configs) => {
+      return this.__postLoad(configs);
     });
   }
 
@@ -83,18 +83,12 @@ class ConfigLoader extends PatternEventEmitter {
     if (this.__loaded) {
       return this.config;
     }
-    this.__loaders = loader.createLoadersSync(this.loaderConfig, { monitor: this.monitor });
-    return this.__postLoad(this.__loaders.map((l) => l.loadSync()));
+    return this.__postLoad(this.locations.map((location) => location.loadSync()));
   }
 
   __mergeConfigs(configs) {
-    return processor(_.cloneDeep(this.config), configs, {
-      environment: this.environment,
-      defaultEnvironment: this.defaultEnvironment,
-      nodeType: this.nodeType,
-      eventEmitter: this,
-      environmentVariables: this.environmentVariables,
-    });
+    const mergedConfigs = configs.reduce((merged, source) => _.merge(merged, source), {});
+    return merger(this.config, mergedConfigs, { eventEmitter: this });
   }
 
   /**
@@ -111,7 +105,7 @@ class ConfigLoader extends PatternEventEmitter {
   }
 
   __listenToChanges() {
-    this.__loaders.forEach((l) =>
+    this.locations.forEach((l) =>
       l.on('change', (path, config) => {
         this.config = this.__mergeConfigs([config]);
       }),

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,16 +28,14 @@ class ConfigLoader extends PatternEventEmitter {
     if (!loaderConfig) {
       throw new Error('A loader configuration is required');
     }
-    const options = opts || {};
-    this.environment = options.environment || process.env.NODE_ENV || null;
-    this.nodeType = options.nodeType || process.env.NODE_TYPE || null;
-    this.environmentVariables = options.environmentVariables || process.env || {};
-    this.defaultEnvironment = options.defaultEnvironment || '*';
     this.config = {};
-    this.monitor = !!options.monitor;
-    this.loaderConfig = loaderConfig;
-    this.loaded = false;
 
+    /**
+     * Set up our child locations. They manage the act of getting all of the
+     * files in a given "location" and merging them together properly.
+     * Our job here is to merge the already-resolved configs together in priority
+     * order
+     */
     this.locations = loaderConfig.locations.map((locationName) => new ConfigLocation(locationName, opts));
   }
 
@@ -88,6 +86,10 @@ class ConfigLoader extends PatternEventEmitter {
 
   __mergeConfigs(configs) {
     const mergedConfigs = configs.reduce((merged, source) => _.merge(merged, source), {});
+    /**
+     * We can't just use the `mergedConfigs` here because the `merger` manages our event
+     * emitter.
+     */
     return merger(this.config, mergedConfigs, { eventEmitter: this });
   }
 
@@ -107,6 +109,10 @@ class ConfigLoader extends PatternEventEmitter {
   __listenToChanges() {
     this.locations.forEach((l) =>
       l.on('change', (path, config) => {
+        /**
+         * When one of our locations reports a change to their
+         * config, merge it in.
+         */
         this.config = this.__mergeConfigs([config]);
       }),
     );

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -23,42 +23,33 @@ const createLoader = (options) => {
   throw new Error('Unable to determine loader type please specify a file location');
 };
 
-const normalizeLocations = (locations, options) =>
-  locations.map((location) => _.merge({}, options, _.isString(location) ? { file: location } : location));
-
 const createLocationsFromGlobedFiles = (location, globedFiles) =>
   globedFiles.map((file) => _.merge({}, location, { file }));
 
-const createLoadersSync = (loaderConfig, options) => {
-  let loaders = [];
-  if (loaderConfig.locations) {
-    const files = normalizeLocations(loaderConfig.locations, options).reduce((globedFiles, location) => {
-      const globPattern = createGlobPattern(location.file);
-      const filesFromGlob = glob.sync(globPattern);
-      return [...globedFiles, ...createLocationsFromGlobedFiles(location, filesFromGlob)];
-    }, []);
-    loaders = files.map((location) => createLoader(location));
-  }
-  return loaders;
+const createLoadersSync = (locationName, options) => {
+  const globPattern = createGlobPattern(locationName.file);
+  const filesFromGlob = glob.sync(globPattern);
+  const files = createLocationsFromGlobedFiles(locationName, filesFromGlob);
+  return files.map((file) =>
+    createLoader({
+      ...options,
+      ...file,
+    }),
+  );
 };
 
-const createLoadersAsync = (loaderConfig, options) => {
-  let loadersPromise = Promise.resolve([]);
-  if (loaderConfig.locations) {
-    const globFilesPromise = normalizeLocations(loaderConfig.locations, options).reduce(
-      (globedFilesPromise, location) =>
-        globedFilesPromise.then((globedFiles) => {
-          const globPattern = createGlobPattern(location.file);
-          return globP(globPattern).then((filesFromGlob) => [
-            ...globedFiles,
-            ...createLocationsFromGlobedFiles(location, filesFromGlob),
-          ]);
+const createLoadersAsync = (locationName, options) => {
+  const globPattern = createGlobPattern(locationName.file);
+  return globP(globPattern)
+    .then((filesFromGlob) => createLocationsFromGlobedFiles(locationName, filesFromGlob))
+    .then((files) =>
+      files.map((file) =>
+        createLoader({
+          ...options,
+          ...file,
         }),
-      Promise.resolve([]),
+      ),
     );
-    loadersPromise = globFilesPromise.then((files) => files.map((location) => createLoader(location)));
-  }
-  return loadersPromise;
 };
 
 module.exports = {

--- a/lib/processor/processor.js
+++ b/lib/processor/processor.js
@@ -4,15 +4,11 @@ const merger = require('./merger');
 const selector = require('./selector');
 const mixin = require('./mixin');
 
-const processConfig = (config, options) => {
-  const merged = mixin(config, options);
-  const mergeEnvConfig = selector(merged, options);
-  return replacer(mergeEnvConfig, options);
-};
-
 const processor = (configToMergeInto, sourceConfigs, options) => {
-  const mergedSource = sourceConfigs.reduce((merged, source) => _.merge(merged, processConfig(source, options)), {});
-  return merger(configToMergeInto, mergedSource, options);
+  const mergedSource = sourceConfigs.reduce((merged, source) => _.merge(merged, mixin(source, options)), {});
+  const mergeEnvConfig = selector(mergedSource, options);
+  const replaced = replacer(mergeEnvConfig, options);
+  return merger(configToMergeInto, replaced, options);
 };
 
 module.exports = processor;

--- a/test/gofigure.spec.js
+++ b/test/gofigure.spec.js
@@ -64,37 +64,28 @@ describe('gofigure', () => {
       describe('from multiple directories', () => {
         it('should merged configs with the specified priority', async () => {
           const locations = [envConf.dir, sharedEnvConf.dir];
+          const sharedDevEnv = _.merge({}, sharedEnvConf.config['*'], sharedEnvConf.config.development);
+          const sharedProdEnv = _.merge({}, sharedEnvConf.config['*'], sharedEnvConf.config.production);
+          const sharedTestEnv = _.merge({}, sharedEnvConf.config['*'], sharedEnvConf.config.test);
 
           const configDev = await goFigure({ environment: 'development', locations }).load();
-          expect(configDev).toEqual(
-            _.merge({}, sharedEnvConf.config['*'], sharedEnvConf.config.development, envConf.config.development),
-          );
+          expect(configDev).toEqual(_.merge({}, sharedDevEnv, envConf.config.development));
 
           const configProd = await goFigure({ environment: 'production', locations }).load();
-          expect(configProd).toEqual(
-            _.merge({}, sharedEnvConf.config['*'], sharedEnvConf.config.production, envConf.config.production),
-          );
+          expect(configProd).toEqual(_.merge({}, sharedProdEnv, envConf.config.production));
 
           const configTest = await goFigure({ environment: 'test', locations }).load();
-          expect(configTest).toEqual(
-            _.merge({}, sharedEnvConf.config['*'], sharedEnvConf.config.test, envConf.config.test),
-          );
+          expect(configTest).toEqual(_.merge({}, sharedTestEnv, envConf.config.test));
 
           const locations2 = [...locations].reverse();
           const configDev2 = await goFigure({ environment: 'development', locations: locations2 }).load();
-          expect(configDev2).toEqual(
-            _.merge({}, sharedEnvConf.config['*'], envConf.config.development, sharedEnvConf.config.development),
-          );
+          expect(configDev2).toEqual(_.merge({}, envConf.config.development, sharedDevEnv));
 
           const configProd2 = await goFigure({ environment: 'production', locations: locations2 }).load();
-          expect(configProd2).toEqual(
-            _.merge({}, sharedEnvConf.config['*'], envConf.config.production, sharedEnvConf.config.production),
-          );
+          expect(configProd2).toEqual(_.merge({}, envConf.config.production, sharedProdEnv));
 
           const configTest2 = await goFigure({ environment: 'test', locations: locations2 }).load();
-          expect(configTest2).toEqual(
-            _.merge({}, sharedEnvConf.config['*'], envConf.config.test, sharedEnvConf.config.test),
-          );
+          expect(configTest2).toEqual(_.merge({}, envConf.config.test, sharedTestEnv));
         });
       });
 

--- a/test/gofigure.spec.js
+++ b/test/gofigure.spec.js
@@ -64,28 +64,37 @@ describe('gofigure', () => {
       describe('from multiple directories', () => {
         it('should merged configs with the specified priority', async () => {
           const locations = [envConf.dir, sharedEnvConf.dir];
-          const sharedDevEnv = _.merge({}, sharedEnvConf.config['*'], sharedEnvConf.config.development);
-          const sharedProdEnv = _.merge({}, sharedEnvConf.config['*'], sharedEnvConf.config.production);
-          const sharedTestEnv = _.merge({}, sharedEnvConf.config['*'], sharedEnvConf.config.test);
 
           const configDev = await goFigure({ environment: 'development', locations }).load();
-          expect(configDev).toEqual(_.merge({}, sharedDevEnv, envConf.config.development));
+          expect(configDev).toEqual(
+            _.merge({}, sharedEnvConf.config['*'], sharedEnvConf.config.development, envConf.config.development),
+          );
 
           const configProd = await goFigure({ environment: 'production', locations }).load();
-          expect(configProd).toEqual(_.merge({}, sharedProdEnv, envConf.config.production));
+          expect(configProd).toEqual(
+            _.merge({}, sharedEnvConf.config['*'], sharedEnvConf.config.production, envConf.config.production),
+          );
 
           const configTest = await goFigure({ environment: 'test', locations }).load();
-          expect(configTest).toEqual(_.merge({}, sharedTestEnv, envConf.config.test));
+          expect(configTest).toEqual(
+            _.merge({}, sharedEnvConf.config['*'], sharedEnvConf.config.test, envConf.config.test),
+          );
 
           const locations2 = [...locations].reverse();
           const configDev2 = await goFigure({ environment: 'development', locations: locations2 }).load();
-          expect(configDev2).toEqual(_.merge({}, envConf.config.development, sharedDevEnv));
+          expect(configDev2).toEqual(
+            _.merge({}, sharedEnvConf.config['*'], envConf.config.development, sharedEnvConf.config.development),
+          );
 
           const configProd2 = await goFigure({ environment: 'production', locations: locations2 }).load();
-          expect(configProd2).toEqual(_.merge({}, envConf.config.production, sharedProdEnv));
+          expect(configProd2).toEqual(
+            _.merge({}, sharedEnvConf.config['*'], envConf.config.production, sharedEnvConf.config.production),
+          );
 
           const configTest2 = await goFigure({ environment: 'test', locations: locations2 }).load();
-          expect(configTest2).toEqual(_.merge({}, envConf.config.test, sharedTestEnv));
+          expect(configTest2).toEqual(
+            _.merge({}, sharedEnvConf.config['*'], envConf.config.test, sharedEnvConf.config.test),
+          );
         });
       });
 


### PR DESCRIPTION
Fixes #46 

Very very very subtle bug. 

2.0.1 made it so that we're stronger about doing location-based overrides, but it broke the behavior found in that issue, where a single location needs to be merged before overrides can happen.

This makes the "ConfigLocation" concept first-class, and makes the `ConfigLoader` a coordinator of the various `ConfigLocations`. `ConfigLocations` are analagous to what `ConfigLoader` used to be, except they only manage a single location & therefore don't care about priority.